### PR TITLE
Feature: add wget protocol support

### DIFF
--- a/src/lib/util/http.lua
+++ b/src/lib/util/http.lua
@@ -123,6 +123,36 @@ local function create_request(method, uri)
         return request, function() end
     end
 
+    self.to_wget_cmd = function ()
+        local parts = {'wget --quiet --output-document=-'}
+
+        if method == 'HEAD' then
+            table.insert(parts, '--method=HEAD')
+        elseif method ~= 'GET' then
+            table.insert(parts, '--method=' .. method)
+        end
+
+        for index, header in ipairs(self.header_list) do
+            local value = self.header_dict[header]
+            if value then
+                local escaped_value = value:gsub('"', '\\"')
+                table.insert(parts, '--header="' .. header .. ': ' .. escaped_value .. '"')
+            end
+        end
+
+        if method ~= 'GET' and method ~= 'HEAD' and #self.body_content > 0 then
+            local escaped_body = self.body_content:gsub('"', '\\"')
+            table.insert(parts, '--body-data="' .. escaped_body .. '"')
+        end
+
+        table.insert(parts, uri)
+
+        local request = table.concat(parts, ' ')
+
+        self = nil
+        return request, function() end
+    end
+
     return self
 end
 

--- a/tests/test_lib_util_http.lua
+++ b/tests/test_lib_util_http.lua
@@ -71,4 +71,38 @@ function test_create_request_no_body_in_get()
     luaunit.assertEquals(request, 'GET / HTTP/1.1\r\n\r\n')
 end
 
+function test_create_request_wget_get()
+    local request = zeebo_util_http.create_request('GET', 'http://example.com')
+        .add_imutable_header('Accept', 'application/json')
+        .to_wget_cmd()
+
+    luaunit.assertEquals(request, 'wget --quiet --output-document=- --header="Accept: application/json" http://example.com')
+end
+
+function test_create_request_wget_post_with_body()
+    local request = zeebo_util_http.create_request('POST', 'http://example.com')
+        .add_imutable_header('Content-Type', 'application/json')
+        .add_body_content('{"key": "value"}')
+        .to_wget_cmd()
+
+    luaunit.assertEquals(request, 'wget --quiet --output-document=- --method=POST --header="Content-Type: application/json" --body-data="{\\"key\\": \\"value\\"}" http://example.com')
+end
+
+function test_create_request_wget_with_headers()
+    local request = zeebo_util_http.create_request('PUT', 'http://example.com')
+        .add_imutable_header('Authorization', 'Bearer token')
+        .add_imutable_header('Content-Type', 'application/json')
+        .add_body_content('{"name": "test"}')
+        .to_wget_cmd()
+
+    luaunit.assertEquals(request, 'wget --quiet --output-document=- --method=PUT --header="Authorization: Bearer token" --header="Content-Type: application/json" --body-data="{\\"name\\": \\"test\\"}" http://example.com')
+end
+
+function test_create_request_wget_head()
+    local request = zeebo_util_http.create_request('HEAD', 'http://example.com')
+        .to_wget_cmd()
+
+    luaunit.assertEquals(request, 'wget --quiet --output-document=- --method=HEAD http://example.com')
+end
+
 os.exit(luaunit.LuaUnit.run())


### PR DESCRIPTION
Adds the `.toWgetProtocol()` function to `http_util.create_request`, enabling the use of wget commands. The behavior is similar to the cURL implementation.
