### PR TITLE
bugfix: iconLarge -> largeIcon in webOS appinfo.json

### DIFF
--- a/src/engine/meta/html5_webos/appinfo.json
+++ b/src/engine/meta/html5_webos/appinfo.json
@@ -6,5 +6,5 @@
     "main": "index.html",
     "title": "{{ meta.title }}",
     "icon": "icon80x80.png",
-    "iconLarge": "icon512x423.png"
+    "largeIcon": "icon512x423.png"
 }


### PR DESCRIPTION
See <https://webostv.developer.lge.com/develop/references/appinfo-json#largeicon>.

The icons should probably also be square.