### PR TITLE
feat: add prepare command to media control

### DIFF
--- a/ee/engine/protocol/media_fsd09.lua
+++ b/ee/engine/protocol/media_fsd09.lua
@@ -98,6 +98,7 @@ local P = {
     play = ccws_command('start'),
     pause = ccws_command('pause'),
     resume = ccws_command('resume'),
+    prepare = ccws_command('prepare'),
     mutex = ccws_mutex,
     error = ccws_error,
     stop = ccws_stop,

--- a/source/engine/api/io/media.lua
+++ b/source/engine/api/io/media.lua
@@ -67,6 +67,7 @@ local function media_create(node, channels, handler)
         -- api
         src = decorator(handler.source),
         play = decorator(handler.play),
+        prepare = decorator(handler.prepare),
         pause = decorator(handler.pause),
         resume = decorator(handler.resume),
         stop = decorator(handler.stop),


### PR DESCRIPTION
This pull request adds support for the media prepare command from CCWS to the Gly Engine.